### PR TITLE
Add same-pile move check

### DIFF
--- a/klondike.py
+++ b/klondike.py
@@ -93,6 +93,9 @@ class Game:
         if src_pile is None or dst_pile is None:
             print("Invalid piles")
             return False
+        if src_pile[src_index] is dst_pile[dst_index]:
+            print("Cannot move to the same pile")
+            return False
         flipped = False
         if source.startswith('T') and count > 1:
             movable = src_pile[src_index][-count:]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -56,6 +56,17 @@ class GameTest(unittest.TestCase):
 
         self.assertTrue(game.is_won())
 
+    def test_move_same_pile(self):
+        game = Game()
+        initial_score = game.score
+        initial_pile = list(game.tableau[0])
+
+        result = game.move('T1', 'T1')
+
+        self.assertFalse(result)
+        self.assertEqual(game.tableau[0], initial_pile)
+        self.assertEqual(game.score, initial_score)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- prevent moving cards within the same pile
- test moving to the same pile and ensure score doesn't change

## Testing
- `python3 -m unittest discover -s tests -p 'test_*.py' -v`